### PR TITLE
Make navbar logo return to homepage

### DIFF
--- a/derecho-laboral.html
+++ b/derecho-laboral.html
@@ -61,7 +61,7 @@
       width: 100%; max-width: 1200px;
       display: flex; align-items: center; justify-content: space-between; position: relative;
     }
-    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .logo-img { width: 100px; height: 100px; object-fit: contain; }
     .logo-text { font-weight: 700; color: #23395d; font-size: 1.23em; letter-spacing: 0.05em; }
     .menu-toggle {
@@ -258,10 +258,10 @@
   <!-- NAV -->
   <nav class="navbar">
     <div class="navbar-content">
-      <div class="logo">
+      <a href="index.html" class="logo">
         <img src="Koop Logo.png" alt="Logo Koop" class="logo-img">
         <div class="logo-text">KOOP STRATEGIC ADVISORY</div>
-      </div>
+      </a>
       <div class="menu-toggle" id="menu-toggle"><span></span><span></span><span></span></div>
       <div class="nav-menu" id="nav-menu">
         <a href="index.html#inicio">INICIO</a>

--- a/derecho-penal.html
+++ b/derecho-penal.html
@@ -61,7 +61,7 @@
       width: 100%; max-width: 1200px;
       display: flex; align-items: center; justify-content: space-between; position: relative;
     }
-    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .logo-img { width: 100px; height: 100px; object-fit: contain; }
     .logo-text { font-weight: 700; color: #23395d; font-size: 1.23em; letter-spacing: 0.05em; }
     .menu-toggle {
@@ -274,10 +274,10 @@
   <!-- NAV -->
   <nav class="navbar">
     <div class="navbar-content">
-      <div class="logo">
+      <a href="index.html" class="logo">
         <img src="Koop Logo.png" alt="Logo Koop" class="logo-img">
         <div class="logo-text">KOOP STRATEGIC ADVISORY</div>
-      </div>
+      </a>
       <div class="menu-toggle" id="menu-toggle"><span></span><span></span><span></span></div>
       <div class="nav-menu" id="nav-menu">
         <a href="index.html#inicio">INICIO</a>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
       width: 100%; max-width: 1200px;
       display: flex; align-items: center; justify-content: space-between; position: relative;
     }
-    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .logo-img { width: 100px; height: 100px; object-fit: contain; }
     .logo-text { font-weight: 700; color: #23395d; font-size: 1.23em; letter-spacing: 0.05em; }
     .menu-toggle {
@@ -316,10 +316,10 @@
   <div id="app">
     <nav class="navbar">
       <div class="navbar-content">
-        <div class="logo">
+        <a href="index.html" class="logo">
           <img src="Koop Logo.png" alt="Logo Koop" class="logo-img">
           <div class="logo-text">KOOP STRATEGIC ADVISORY</div>
-        </div>
+        </a>
         <div class="menu-toggle" id="menu-toggle"><span></span><span></span><span></span></div>
         <div class="nav-menu" id="nav-menu">
           <a href="index.html#inicio">INICIO</a>

--- a/tramites-notariales.html
+++ b/tramites-notariales.html
@@ -61,7 +61,7 @@
       width: 100%; max-width: 1200px;
       display: flex; align-items: center; justify-content: space-between; position: relative;
     }
-    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
     .logo-img { width: 100px; height: 100px; object-fit: contain; }
     .logo-text { font-weight: 700; color: #23395d; font-size: 1.23em; letter-spacing: 0.05em; }
     .menu-toggle {
@@ -274,10 +274,10 @@
   <!-- NAV -->
   <nav class="navbar">
     <div class="navbar-content">
-      <div class="logo">
+      <a href="index.html" class="logo">
         <img src="Koop Logo.png" alt="Logo Koop" class="logo-img">
         <div class="logo-text">KOOP STRATEGIC ADVISORY</div>
-      </div>
+      </a>
       <div class="menu-toggle" id="menu-toggle"><span></span><span></span><span></span></div>
       <div class="nav-menu" id="nav-menu">
         <a href="index.html#inicio">INICIO</a>


### PR DESCRIPTION
## Summary
- Make the navbar logo and title link back to the homepage on all pages.
- Remove the underline from the firm name in the navbar.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0d287d0c83278ed78fa96512dfd2