### PR TITLE
Remove ABOGADOS link from navigation across site

### DIFF
--- a/acciones-de-tutela.html
+++ b/acciones-de-tutela.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/auditoria.html
+++ b/auditoria.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/contratacion-publica.html
+++ b/contratacion-publica.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/derecho-administrativo.html
+++ b/derecho-administrativo.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/derecho-familia.html
+++ b/derecho-familia.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/derecho-laboral.html
+++ b/derecho-laboral.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/derecho-penal.html
+++ b/derecho-penal.html
@@ -283,7 +283,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -398,7 +397,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/impuestos.html
+++ b/impuestos.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -325,7 +325,6 @@
           <a href="index.html#inicio">INICIO</a>
           <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
           <a href="index.html#vision">NUESTRA VISIÓN</a>
-          <a href="index.html#abogados">ABOGADOS</a>
           <a href="index.html#contacto">CONTACTO</a>
         </div>
       </div>

--- a/insolvencia.html
+++ b/insolvencia.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/planeacion-patrimonial.html
+++ b/planeacion-patrimonial.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/resolucion-disputas.html
+++ b/resolucion-disputas.html
@@ -267,7 +267,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -386,7 +385,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>

--- a/tramites-notariales.html
+++ b/tramites-notariales.html
@@ -283,7 +283,6 @@
         <a href="index.html#inicio">INICIO</a>
         <a href="index.html#areas">ÁREAS DE PRÁCTICA</a>
         <a href="index.html#vision">NUESTRA VISIÓN</a>
-        <a href="index.html#abogados">ABOGADOS</a>
         <a href="index.html#contacto">CONTACTO</a>
       </div>
     </div>
@@ -398,7 +397,6 @@
           <li><a href="index.html#inicio">Inicio</a></li>
           <li><a href="index.html#areas">Áreas de práctica</a></li>
           <li><a href="index.html#vision">Nuestra visión</a></li>
-          <li><a href="index.html#abogados">Abogados</a></li>
           <li><a href="index.html#contacto">Contacto</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- Drop "ABOGADOS" link from navigation menu in all HTML pages for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `rg -i abogados`

------
https://chatgpt.com/codex/tasks/task_e_68a219ec2f748327b50bde90467e45a2