### PR TITLE
Ajusta tarjetas de áreas y botón Ingresar

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
     .areas-title-normal { font-weight: 300; color: #4877b1; }
     .areas-cards{
       flex: 1 1 64%; background:#fff; box-sizing:border-box;
-      display:grid; gap:22px; padding:40px 40px 40px 24px;
+      display:grid; gap:16px; padding:24px;
       grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
     }
 
@@ -212,7 +212,7 @@
       text-shadow:0 3px 18px rgba(0,0,0,.35);
     }
     .labor-card-btn{
-      align-self:flex-start; background:var(--koop-acento); color:#fff;
+      align-self:flex-end; background:var(--koop-acento); color:#fff;
       padding:8px 20px; border-radius:30px; font-weight:700; font-size:.95rem;
       margin-top:10px; transition:background .2s;
     }


### PR DESCRIPTION
## Summary
- Reduce el padding y el espacio entre tarjetas de Áreas de Práctica para aprovechar mejor el espacio.
- Coloca el botón **Ingresar** en la esquina inferior derecha de cada tarjeta.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2247fefc08327aa6375b99afde0b8