### PR TITLE
Expand practice area buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,9 +212,9 @@
       text-shadow:0 3px 18px rgba(0,0,0,.35);
     }
     .labor-card-btn{
-      align-self:flex-end; background:var(--koop-acento); color:#fff;
-      padding:8px 20px; border-radius:30px; font-weight:700; font-size:.95rem;
-      margin-top:10px; transition:background .2s;
+      align-self:stretch; background:var(--koop-acento); color:#fff;
+      width:100%; text-align:center; padding:8px 0; border-radius:30px;
+      font-weight:700; font-size:.95rem; margin-top:10px; transition:background .2s;
     }
     .labor-card-btn:hover{ background:#c67616; }
 


### PR DESCRIPTION
## Summary
- widen practice area buttons to use full card width for better visual balance

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a226a917e0832793b934b0d82e5762