### PR TITLE
Expand legal section container

### DIFF
--- a/derecho.html
+++ b/derecho.html
@@ -128,6 +128,7 @@
     }
     .labor-cards-container{
       max-width:1200px; margin:0 auto; text-align:center; color: var(--koop-azul);
+      min-height:100vh; display:flex; flex-direction:column; justify-content:center;
     }
     .labor-tag{
       display:inline-block; background: var(--koop-acento); color:#1f2b3d;


### PR DESCRIPTION
## Summary
- Expand the legal cards container to take the full viewport height and center its contents.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22923924c832790edc9fc1eb1d0fa