### PR TITLE
Amplia contenedor de áreas de práctica

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,22 +181,25 @@
       width: 100%; background: linear-gradient(90deg, #e9f0fa 36%, #fff 36%); display: flex; justify-content: center; align-items: stretch;
       padding: 0; box-sizing: border-box;
     }
-    .areas-container { display: flex; flex-direction: row; width: 100%; max-width: 1200px; min-height: 360px; }
+    .areas-container { display: flex; flex-direction: row; width: 100%; min-height: 500px; }
     .areas-title {
       flex: 0 0 36%; background: #e9f0fa; display: flex; flex-direction: column; justify-content: center; align-items: flex-start;
-      padding: 60px 40px; font-size: 2.3em; font-weight: 400; color: #1d3557; letter-spacing: 0.02em; margin-left: 4cm;
+      padding: 60px 40px; font-size: 2.3em; font-weight: 400; color: #1d3557; letter-spacing: 0.02em;
     }
     .areas-title-bold { font-weight: 700; color: #ee9626; }
     .areas-title-normal { font-weight: 300; color: #4877b1; }
     .areas-cards{
       flex: 1 1 64%; background:#fff; box-sizing:border-box;
       display:grid; gap:16px; padding:24px;
-      grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+      grid-template-columns:1fr;
+      width:100%;
+      height:100%;
     }
 
     .labor-card{
       position:relative; border-radius:14px; overflow:hidden;
       min-height:300px; background:#ccc; display:block; text-decoration:none;
+      height:100%;
     }
     .labor-card::before{
       content:""; position:absolute; inset:0;


### PR DESCRIPTION
## Summary
- Elimina el límite de ancho y márgenes en la sección de Áreas de Práctica.
- Las tarjetas ahora ocupan todo el ancho disponible en el contenedor.

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68a22b8ffd408327b9f5ad9aeb53da16