### PR TITLE
Ampliar sección de áreas de trabajo

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,18 +178,18 @@
     .cta-btn:hover { background: #c67616; }
 
     .areas-section {
-      width: 100%; background: linear-gradient(90deg, #e9f0fa 36%, #fff 36%); display: flex; justify-content: center; align-items: stretch;
+      width: 100%; background: linear-gradient(90deg, #e9f0fa 30%, #fff 30%); display: flex; justify-content: center; align-items: stretch;
       padding: 0; box-sizing: border-box;
     }
     .areas-container { display: flex; flex-direction: row; width: 100%; max-width: 1200px; min-height: 500px; }
     .areas-title {
-      flex: 0 0 36%; background: #e9f0fa; display: flex; flex-direction: column; justify-content: center; align-items: flex-start;
-      padding: 60px 40px; font-size: 2.3em; font-weight: 400; color: #1d3557; letter-spacing: 0.02em; margin-left: 4cm;
+      flex: 0 0 30%; background: #e9f0fa; display: flex; flex-direction: column; justify-content: center; align-items: flex-start;
+      padding: 60px 40px; font-size: 2.3em; font-weight: 400; color: #1d3557; letter-spacing: 0.02em;
     }
     .areas-title-bold { font-weight: 700; color: #ee9626; }
     .areas-title-normal { font-weight: 300; color: #4877b1; }
     .areas-cards{
-      flex: 1 1 64%; background:#fff; box-sizing:border-box;
+      flex: 1 1 70%; background:#fff; box-sizing:border-box;
       display:grid; gap:16px; padding:24px;
       grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
       height:100%;


### PR DESCRIPTION
## Resumen
- Ajusta proporciones y gradiente de la sección de áreas de trabajo para ampliar la zona de tarjetas.
- Elimina margen lateral del título y aumenta el ancho del contenedor de tarjetas.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2314d4f4483278ef3bff52543ec00