### PR TITLE
Ajustar menú de Áreas de práctica

### DIFF
--- a/acciones-de-tutela.html
+++ b/acciones-de-tutela.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/auditoria.html
+++ b/auditoria.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/contabilidad.html
+++ b/contabilidad.html
@@ -466,10 +466,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/contratacion-publica.html
+++ b/contratacion-publica.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/derecho-administrativo.html
+++ b/derecho-administrativo.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/derecho-familia.html
+++ b/derecho-familia.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/derecho-laboral.html
+++ b/derecho-laboral.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/derecho-penal.html
+++ b/derecho-penal.html
@@ -525,10 +525,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/derecho.html
+++ b/derecho.html
@@ -472,10 +472,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/impuestos.html
+++ b/impuestos.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -510,10 +510,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/insolvencia.html
+++ b/insolvencia.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/planeacion-patrimonial.html
+++ b/planeacion-patrimonial.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/resolucion-disputas.html
+++ b/resolucion-disputas.html
@@ -518,10 +518,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 

--- a/tramites-notariales.html
+++ b/tramites-notariales.html
@@ -525,10 +525,8 @@
     const areasToggle = document.getElementById('areas-toggle');
     if(areasToggle){
       areasToggle.addEventListener('click', (e)=>{
-        if(window.innerWidth <= 700){
-          e.preventDefault();
-          areasToggle.parentElement.classList.toggle('open');
-        }
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
       });
     }
 


### PR DESCRIPTION
## Summary
- Permite abrir y cerrar el dropdown de "Áreas de práctica" al hacer clic, evitando la redirección.
- Se replica el comportamiento en la navegación de todas las páginas.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2f759388327b9cc8acd22c9c112