### PR TITLE
Add privacy policy page with shared navigation

### DIFF
--- a/privacidad.html
+++ b/privacidad.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+  <title>Política de Privacidad | Koop Strategic Advisory</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    :root{
+      --nav-h: 64px;
+      --koop-azul:#23395d;
+      --koop-azul-claro:#e9f0fa;
+      --koop-acento:#ee9626;
+      --koop-bullet:#2998ff;
+      --gris-100:#f5f7fb;
+      --gris-300:#c9d3e6;
+      --gris-500:#8fa1bf;
+      --negro:#0e1320;
+    }
+    html, body {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      overflow-x: hidden;
+      height: 100%;
+      font-family: 'Montserrat', Arial, sans-serif;
+      background: #141b2d;
+      color: #fff;
+    }
+    *, *::before, *::after { box-sizing: inherit; }
+
+    .page-transition{
+      position: fixed; inset: 0; background: #141b2d;
+      z-index: 9998; opacity: 0; pointer-events: none;
+      transition: opacity .6s ease;
+    }
+    .page-transition.is-active{ opacity:1; pointer-events:auto; }
+
+    .navbar {
+      width: 100%;
+      display: flex; align-items: center; justify-content: center;
+      padding: 0 40px; background: #fff;
+      position: fixed; top: 0; left: 0;
+      z-index: 100; box-shadow: 0 2px 8px #0001; height: var(--nav-h);
+    }
+    .navbar-content {
+      width: 100%; max-width: 1200px;
+      display: flex; align-items: center; justify-content: space-between; position: relative;
+    }
+    .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+    .logo-img { width: 100px; height: 100px; object-fit: contain; }
+    .logo-text { font-weight: 700; color: #23395d; font-size: 1.23em; letter-spacing: 0.05em; }
+    .menu-toggle {
+      display: none; flex-direction: column; justify-content: center;
+      cursor: pointer; width: 36px; height: 36px; margin-left: 12px; z-index: 20;
+    }
+    .menu-toggle span { height: 4px; background: #23395d; margin: 5px 0; border-radius: 2px; transition: .4s; display: block; }
+    .nav-menu { display: flex; gap: 36px; align-items: center; justify-content: center; }
+    .nav-menu a { color: #23395d; text-decoration: none; font-weight: 500; font-size: 1em; letter-spacing: .02em; transition: color .2s; }
+    .nav-menu a:hover { color: var(--koop-acento); }
+
+    .dropdown { position: relative; }
+    .drop-btn { display: flex; align-items: center; }
+    .drop-btn::after { content: "\25BE"; margin-left: 4px; font-size: .8em; }
+    .dropdown-content {
+      display: none; position: absolute; top: calc(100% + 10px); left: 0;
+      background: #fff; padding: 16px 24px; box-shadow: 0 4px 18px #0002;
+      border-radius: 8px; z-index: 100; gap: 32px;
+    }
+    @media (hover: hover) {
+      .dropdown:hover .dropdown-content { display: flex; }
+    }
+    .dropdown-group { display: flex; flex-direction: column; }
+    .dropdown-title { font-weight:700; color:#23395d; margin-bottom:8px; }
+    .dropdown-content a { color:#23395d; text-decoration:none; margin:4px 0; }
+    @media (max-width:700px){
+      .dropdown-content{position:static; box-shadow:none; padding:0; gap:0; display:none; flex-direction:column;}
+      .dropdown.open .dropdown-content{display:flex;}
+      .dropdown-content a{padding:6px 0;}
+    }
+    @media (max-width:700px){
+      .navbar { height: var(--nav-h); padding: 0 10px; }
+      .logo-img { width: 56px; height: 56px; }
+      .logo-text { font-size: .95em; }
+      .menu-toggle { display: flex; }
+      .nav-menu {
+        display: none; position: absolute; top: var(--nav-h); left: 0; right: 0; background: #fff;
+        flex-direction: column; align-items: center; gap: 18px; padding: 24px 0 18px; z-index: 99; box-shadow: 0 6px 24px #0002;
+      }
+      .nav-menu.open { display: flex; animation: fadeIn .25s; }
+      @keyframes fadeIn { from { opacity: 0; transform: translateY(-12px);} to { opacity: 1; transform: translateY(0);} }
+    }
+
+    main { padding: 96px 20px 40px; max-width: 800px; margin: 0 auto; color: #23395d; }
+    h1 { color: #23395d; }
+    footer{
+      position: relative;
+      color:#e8f0ff;
+      background: url('Img23_Atrio.jpg') center center/cover no-repeat;
+      isolation: isolate;
+    }
+    footer::before{
+      content:""; position:absolute; inset:0; background: rgba(33,56,99,0.86);
+    }
+    .footer-container{
+      position: relative; z-index:1; max-width:1200px; margin:0 auto; padding:24px 20px;
+      display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px;
+    }
+    .footer-left{font-size:.9em;}
+    .footer-right a{color:#e8f0ff; text-decoration:none;}
+  </style>
+</head>
+<body>
+  <div class="page-transition"></div>
+  <nav class="navbar">
+    <div class="navbar-content">
+      <a href="index.html" class="logo">
+        <img src="Koop Logo.png" alt="Logo Koop" class="logo-img" />
+        <div class="logo-text">KOOP STRATEGIC ADVISORY</div>
+      </a>
+      <div class="menu-toggle" id="menu-toggle"><span></span><span></span><span></span></div>
+      <div class="nav-menu" id="nav-menu">
+        <a href="index.html#inicio">INICIO</a>
+        <div class="dropdown">
+          <a href="index.html#areas" class="drop-btn" id="areas-toggle">ÁREAS DE PRÁCTICA</a>
+          <div class="dropdown-content">
+            <div class="dropdown-group">
+              <span class="dropdown-title">Derecho</span>
+              <a href="derecho-laboral.html">Derecho Laboral</a>
+              <a href="derecho-penal.html">Derecho Penal</a>
+              <a href="tramites-notariales.html">Trámites notariales</a>
+              <a href="derecho-administrativo.html">Derecho Administrativo</a>
+              <a href="derecho-familia.html">Derecho de Familia</a>
+              <a href="contratacion-publica.html">Contratación Pública</a>
+              <a href="resolucion-disputas.html">Resolución de Disputas</a>
+              <a href="acciones-de-tutela.html">Acciones de Tutela</a>
+              <a href="insolvencia.html">Insolvencia</a>
+            </div>
+            <div class="dropdown-group">
+              <span class="dropdown-title">Contabilidad</span>
+              <a href="contabilidad.html">Contabilidad</a>
+              <a href="auditoria.html">Auditoría</a>
+              <a href="impuestos.html">Impuestos</a>
+              <a href="planeacion-patrimonial.html">Planeación Patrimonial</a>
+            </div>
+          </div>
+        </div>
+        <a href="index.html#vision">NUESTRA VISIÓN</a>
+        <a href="index.html#contacto">CONTACTO</a>
+      </div>
+    </div>
+  </nav>
+  <main>
+    <h1>Política de Privacidad</h1>
+    <p>Esta página describe las políticas de privacidad de Koop Strategic Advisory. Su contenido se actualizará próximamente.</p>
+  </main>
+  <footer class="site-footer">
+    <div class="footer-container">
+      <div class="footer-left">© <span id="year"></span> Creado por Koop Strategic Advisory</div>
+      <div class="footer-right"><a href="privacidad.html">Política de Privacidad</a></div>
+    </div>
+  </footer>
+  <script>
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+      menuToggle.onclick = () => navMenu.classList.toggle('open');
+      navMenu.querySelectorAll('a').forEach(link => {
+        if(!link.classList.contains('drop-btn')){
+          link.onclick = () => navMenu.classList.remove('open');
+        }
+      });
+    }
+    const areasToggle = document.getElementById('areas-toggle');
+    if(areasToggle){
+      areasToggle.addEventListener('click', (e)=>{
+        e.preventDefault();
+        areasToggle.parentElement.classList.toggle('open');
+      });
+    }
+    const y = document.getElementById('year');
+    if (y) y.textContent = new Date().getFullYear();
+    (function () {
+      const overlay = document.querySelector('.page-transition');
+      function hideOverlay() { if (overlay) { overlay.classList.remove('is-active'); } }
+      hideOverlay();
+      window.addEventListener('pageshow', (e) => { if (e.persisted) hideOverlay(); });
+      window.addEventListener('focus', hideOverlay);
+      window.addEventListener('load', hideOverlay);
+      function shouldIntercept(link) {
+        if (!link.href) return false;
+        if (link.target && link.target.toLowerCase() === '_blank') return false;
+        const href = link.getAttribute('href');
+        if (!href) return false;
+        if (href.startsWith('#')) return false;
+        if (href.startsWith('mailto:') || href.startsWith('tel:')) return false;
+        const url = new URL(link.href, window.location.href);
+        if (url.hostname !== window.location.hostname) return false;
+        if (url.pathname === window.location.pathname && url.hash) return false;
+        return true;
+      }
+      document.addEventListener('click', (e) => {
+        const a = e.target.closest('a');
+        if (!a || !shouldIntercept(a)) return;
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+        e.preventDefault();
+        overlay && overlay.classList.add('is-active');
+        setTimeout(() => { window.location.href = a.href; }, 600);
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `privacidad.html` with the same navigation menu and dropdown for practice areas as other pages
- Include common footer and page transition script for consistent behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a899b651ac8327aabbe39feb9550fa